### PR TITLE
Set CF_ACCOUNT_ID env var from secrets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           environment: 'production'
+        env: 
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
 
       # these folders have secrets/configs in them that prevent the cache from running successfully
       # TODO: remove when https://github.com/actions/cache/issues/133 has a solution


### PR DESCRIPTION
Hey @cherry! We're working on a [deploy tool](https://deploy.workers.cloudflare.com) for Cloudflare Workers apps, and we really want to include this project in the list of cool stuff to deploy!

This adds a missing piece in the deploy workflow to get it working with the tool — specifically, passing in a `CF_ACCOUNT_ID` env var based on the `CF_ACCOUNT_ID` secret, which will be set by the deploy tool.

It should pass through transparently if that secret isn't set, so it'll deploy for you as it has in the past, but for anyone that forks and provides their own secret there, it'll deploy to their account 👍